### PR TITLE
Fix: remove Git Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/novela"]
-	path = themes/novela
-	url = https://github.com/forestryio/hugo-theme-novela.git


### PR DESCRIPTION
Prevent SSH error when cloning the  repository from  GitLab.